### PR TITLE
changes the wording to only require the approval of one maintainer fo…

### DIFF
--- a/open_source_maintenance_policy.md
+++ b/open_source_maintenance_policy.md
@@ -70,7 +70,7 @@ Releases should not block on features on the roadmap, rather they should happen 
 
 * Open Pull Request (anyone)
 * Code reviewed by a Maintainer, Sergeant, or Project Lead - who will then approve or request changes to the pull request using Github's reviewing tool.
-* Merged after approvals by at least two Maintainers for the component(s) affected by your contribution.
+* Merged after approvals by at least one Maintainer for the component(s) affected by your contribution.
 
 ## Contribution Appeals Process
 


### PR DESCRIPTION
…r contributions

Hello!

Since we currently have so few core maintainers for our projects (though I hope to change that soon!) - I'd like to require the approval of only one maintainer for a contribution, rather than two.